### PR TITLE
This moves where it is decided to display the resize handle to the el…

### DIFF
--- a/Grid/Element.razor
+++ b/Grid/Element.razor
@@ -20,7 +20,10 @@
                     @ChildContent
                 </div>
             </div>
-            <ResizeHandle />
+            @if(Grid.AllowResize)
+            {
+                <ResizeHandle />
+            }            
         </div>
     }
 </CascadingValue>

--- a/Grid/__Internal/ResizeHandle.razor
+++ b/Grid/__Internal/ResizeHandle.razor
@@ -1,4 +1,1 @@
-﻿@if (Element.Grid.AllowResize)
-{
-    <div class="eg-rh" @onmousedown="MouseDownAsync" @onmouseup="MouseUpAsync" @onmousemove="MouseMoveAsync"></div>
-}
+﻿<div class="eg-rh" @onmousedown="MouseDownAsync" @onmouseup="MouseUpAsync" @onmousemove="MouseMoveAsync"></div>


### PR DESCRIPTION
…ement and out of the resize handle. This is because the resize handle does not re-render when AllowResize changes. This means the ResizeHandle is not shown when you dynamically set AllowResize. It seemed to make more sense to move the display condition than add update handling to the ResizeHandle component.